### PR TITLE
Updates related to changes in TaylorIntegration and more (#63)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ os:
   - osx
 
 julia:
-  - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
 
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -15,17 +15,17 @@ TaylorIntegration = "92b13dbe-c966-51a2-8445-caca9f8a7d42"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
-Documenter = "≥ 0.22.1"
-IntervalArithmetic = "≥ 0.15.1"
-Reexport = "≥ 0.2.0"
-TaylorIntegration = "≥ 0.5.0"
-TaylorSeries = "≥ 0.10.0"
-julia = "≥ 1.0.0"
+Documenter = "^0.22.1"
+IntervalArithmetic = "^0.15.1, ^0.16.0"
+IntervalRootFinding = "^0.5.1"
+Reexport = "^0.2.0"
+TaylorIntegration = "^0.7.0"
+TaylorSeries = "^0.10.0"
+julia = "1.1"
 
 [extras]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "LinearAlgebra", "Test"]
+test = ["LinearAlgebra", "Test"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-  - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/src/TaylorModels.jl
+++ b/src/TaylorModels.jl
@@ -35,7 +35,7 @@ export remainder, polynomial, domain,
 
 include("constructors.jl")
 include("auxiliary.jl")
-include("promotion.jl")
+# include("promotion.jl")
 include("bounds.jl")
 include("evaluate.jl")
 include("rpa_functions.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using TaylorModels
 include("TM1.jl")
 include("TMN.jl")
 include("shrink-wrapping.jl")
+include("validated_integ.jl")

--- a/test/validated_integ.jl
+++ b/test/validated_integ.jl
@@ -1,0 +1,87 @@
+# Tests for validated_integ
+
+using TaylorModels
+using LinearAlgebra: norm
+using Test
+
+setformat(:full)
+
+# NOTE: IntervalArithmetic v0.16.0 includes this function; but
+# IntervalRootFinding is bounded to use v0.15.x
+interval_rand(X::Interval{T}) where {T} = X.lo + rand(T) * (X.hi - X.lo)
+interval_rand(X::IntervalBox) = interval_rand.(X)
+
+@testset "Tests for `validated_integ`" begin
+    @testset "Forward integration" begin
+        @taylorize function falling_ball!(dx, x, p, t)
+            dx[1] = x[2]
+            dx[2] = -one(x[1])
+            nothing
+        end
+        exactsol(t, t0, x0) =
+            (x0[1] + x0[2]*(t-t0) - 0.5*(t-t0)^2, x0[2] - (t-t0))
+
+        # Initial conditions
+        tini, tend = 0.0, 10.0
+        q0 = [10.0, 0.0]
+        δq0 = IntervalBox(-0.25 .. 0.25, Val(2))
+
+        # Parameters
+        abstol = 1e-20
+        orderQ = 2
+        orderT = 4
+        ξ = set_variables("ξₓ ξᵥ", order=2*orderQ, numvars=length(q0))
+        normalized_box = IntervalBox(-1 .. 1, Val(orderQ))
+
+        tTM, qv, qTM = validated_integ(falling_ball!, q0, δq0,
+            tini, tend, orderQ, orderT, abstol)
+
+        @test length(qv) == length(qTM[1, :]) == length(tTM)
+        @test length(tTM) < 501
+
+        for n = 2:length(tTM)
+            for it = 1:10
+                δt = interval_rand(domain(qTM[1,n]))
+                q0ξ = interval_rand(δq0)
+                q = evaluate.(evaluate.(qTM[:,n], δt), (normalized_box,))
+                @test all(exactsol(tTM[n-1]+δt, tini, q0 .+ q0ξ) .∈ q)
+            end
+        end
+    end
+
+    @testset "Backward integration" begin
+        @taylorize function falling_ball!(dx, x, p, t)
+            dx[1] = x[2]
+            dx[2] = -one(x[1])
+            nothing
+        end
+        exactsol(t, t0, x0) = (x0[1] + x0[2]*(t-t0) - 0.5*(t-t0)^2, x0[2] - (t-t0))
+
+        # Initial conditions
+        tini, tend = 10.0, 0.0
+        q0 = [10.0, 0.0]
+        δq0 = IntervalBox(-0.25 .. 0.25, Val(2))
+
+        # Parameters
+        abstol = 1e-20
+        orderQ = 2
+        orderT = 4
+        ξ = set_variables("ξₓ ξᵥ", order=2*orderQ, numvars=length(q0))
+        normalized_box = IntervalBox(-1 .. 1, Val(orderQ))
+
+        tTM, qv, qTM = validated_integ(falling_ball!, q0, δq0,
+            tini, tend, orderQ, orderT, abstol)
+
+        @test length(qv) == length(qTM[1, :]) == length(tTM)
+        @test length(tTM) < 501
+
+        for n = 2:length(tTM)
+            for it = 1:10
+                δt = interval_rand(domain(qTM[1,n]))
+                q0ξ = interval_rand(δq0)
+                q = evaluate.(evaluate.(qTM[:,n], δt), (normalized_box,))
+                @test all(exactsol(tTM[n-1]+δt, tini, q0 .+ q0ξ) .∈ q)
+            end
+        end
+    end
+end


### PR DESCRIPTION
* Update usage of taylorstep!

* Upper bounds in Project.toml and fixes

* Update travis, appveyor, and fix version of IntervalArithmetic

* Implement validated backward integration with tests

* Add validated_integ.jl to runtests.jl

* Do not include promotion.jl

* Extend bounds of IntervalArithmetic to ^0.16.0

* Use a locally defined `rand` for intervals and intervalboxes

... needed because IntervalRootFindinding is bounded to use v0.15.x

* Use v0.5.1 or above of IntervalRootFinding

* Mostly cosmetic changes